### PR TITLE
Feat: Add staggered animation to filter group reveal

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -922,7 +922,31 @@ a:focus:not(:focus-visible) {
     flex-direction: column; /* Stack label and select vertically */
     gap: 0.5rem; /* Space between label and select */
     min-width: 200px; /* Minimum width for filter groups */
+    opacity: 0;
+    transform: translateY(-10px);
+    transition: opacity 0.3s ease-out, transform 0.3s ease-out;
 }
+
+.filter-controls:not(.filters-collapsed) .filter-group {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* Staggered delays for filter groups */
+.filter-controls:not(.filters-collapsed) .filter-group:nth-child(1) {
+    transition-delay: 0.1s; /* Delay for opacity/transform when appearing */
+}
+.filter-controls:not(.filters-collapsed) .filter-group:nth-child(2) {
+    transition-delay: 0.2s;
+}
+.filter-controls:not(.filters-collapsed) .filter-group:nth-child(3) {
+    transition-delay: 0.3s;
+}
+/* Reset button is the 4th direct child flex item in filter-controls */
+.filter-controls:not(.filters-collapsed) #reset-filters-btn {
+    transition-delay: 0.4s;
+}
+
 
 .filter-group label {
     font-weight: 600;
@@ -969,7 +993,17 @@ a:focus:not(:focus-visible) {
     transition: background-color 0.3s ease, transform 0.2s ease;
     margin-top: 0; /* Reset margin from generic .btn if any conflict */
     align-self: flex-end; /* Align with the bottom of other controls */
+    opacity: 0; /* Initial state for animation */
+    transform: translateY(-10px); /* Initial state for animation */
+    transition: opacity 0.3s ease-out, transform 0.3s ease-out; /* Same transition as filter-group */
 }
+
+.filter-controls:not(.filters-collapsed) #reset-filters-btn {
+    opacity: 1; /* Visible state */
+    transform: translateY(0); /* Visible state */
+    /* transition-delay is already set using :nth-child logic, but specifically targeting it here for clarity if needed */
+}
+
 
 #reset-filters-btn:hover {
     background-color: #e6a400; /* Darker accent */


### PR DESCRIPTION
Enhanced the collapsible filter section with a staggered animation for individual filter groups and the reset button.

- Modified CSS to set initial opacity and transform for filter items.
- Applied staggered `transition-delay`s to each filter item when the main filter section opens, causing them to animate in sequentially.
- This creates a more dynamic and polished appearance for the filter reveal.